### PR TITLE
Add ja to LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -6,3 +6,4 @@ tr_TR
 pl
 fr
 ca
+ja


### PR DESCRIPTION
Hello,
I've translated Notejot into Japanese before. However, I completely forgot to add `ja` to `LINGUAS` though I read `How to Translate Notejot`. This is my apologies.
I found this mistake today and fixed it. Also, I confirmed that my translation worked well at my end by building this app.

## Changes Summary

- Added `ja` to `LINGUAS`.