### PR TITLE
Remove '.desktop' from id tag in appdata.xml

### DIFF
--- a/data/com.github.lainsce.notejot.appdata.xml.in
+++ b/data/com.github.lainsce.notejot.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-    <id>com.github.lainsce.notejot.desktop</id>
+    <id>com.github.lainsce.notejot</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0+</project_license>
     <name>Notejot</name>


### PR DESCRIPTION
Fixes the appcenter bot creates "Appstream tests fail" issues
