### PR TITLE
Use standard icon name

### DIFF
--- a/src/EditableLabel.vala
+++ b/src/EditableLabel.vala
@@ -90,7 +90,7 @@ public class Notejot.EditableLabel : Gtk.EventBox {
         title.hexpand = true;
 
         var edit_button = new Gtk.Button ();
-        edit_button.image = new Gtk.Image.from_icon_name ("edit-symbolic", Gtk.IconSize.MENU);
+        edit_button.image = new Gtk.Image.from_icon_name ("document-edit-symbolic", Gtk.IconSize.MENU);
         edit_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         var button_revealer = new Gtk.Revealer ();
         button_revealer.valign = Gtk.Align.CENTER;


### PR DESCRIPTION
edit-symbolic icon is missing from the default Adwaita icon theme. Use document-edit-symbolic instead.