### PR TITLE
Hide notes from the taskbar and the pager

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -74,6 +74,9 @@ namespace Notejot {
             this.get_style_context().add_class("notejot-window");
             this.uid = uid_counter++;
 
+            this.set_skip_taskbar_hint(true);
+            this.set_skip_pager_hint(true);
+
             update_theme();
 
             header = new Gtk.HeaderBar();


### PR DESCRIPTION
I think it's not really practical to show every notes on the taskbar and the pager. They should be hidden as they are desktop components.