### PR TITLE
Application.vala - Fix i18n

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -32,6 +32,12 @@ namespace Notejot {
             gsettings = new GLib.Settings ("io.github.lainsce.Notejot");
         }
 
+        construct {
+            Intl.setlocale (LocaleCategory.ALL, "");
+            Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.GNOMELOCALEDIR);
+            Intl.textdomain (Config.GETTEXT_PACKAGE);
+        }
+
         protected override void activate () {
             if (win != null) {
                 win.present ();


### PR DESCRIPTION
After some research, I found out that `bindtextdomain()` is missing to make it properly work ([source](https://www.gnu.org/software/gettext/FAQ.html#integrating_howto)).
Please feel free to make any changes to commit message or code itself as I'm not familiar with Vala.

Tested on Notejot Devel:
![notejot](https://user-images.githubusercontent.com/42654671/109515162-afee8d00-7a9e-11eb-8aa9-7eb92413c53b.png)

Fixes #213 #214