### PR TITLE
Fixing #258 App won't use dark mode when there are no notes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,7 @@ asresources = gnome.compile_resources(
 sources = files(
    'src/Application.vala',
     'src/MainWindow.vala',
+    'src/Settings.vala',
     'src/Services/TaskManager.vala',
     'src/Services/Utils.vala',
     'src/Views/ListView.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,7 +20,7 @@
 namespace Notejot {
     public class Application : Gtk.Application {
         public static MainWindow win = null;
-        public static GLib.Settings gsettings;
+        public static Settings gsettings;
         private const GLib.ActionEntry app_entries[] = {
             { "quit", on_quit },
         };
@@ -33,7 +33,7 @@ namespace Notejot {
             add_action_entries(app_entries, this);
         }
         static construct {
-            gsettings = new GLib.Settings ("io.github.lainsce.Notejot");
+            gsettings = new Settings ();
         }
 
         construct {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -74,6 +74,7 @@ namespace Notejot {
         // Etc
         public bool pinned = false;
         int uid = 0;
+        public Gtk.Settings gtk_settings;
 
         public GLib.ListStore notestore;
         public GLib.ListStore trashstore;
@@ -171,7 +172,17 @@ namespace Notejot {
 
             var action_fontsize = Notejot.Application.gsettings.create_action ("font-size");
             app.add_action(action_fontsize);
-            //
+            
+            // GtkSettings and dark theme
+            gtk_settings = Gtk.Settings.get_default ();
+            Application.gsettings.bind_property (
+                "dark-mode",
+                gtk_settings,
+                "gtk-application-prefer-dark-theme",
+                GLib.BindingFlags.SYNC_CREATE
+                // This allows to sync gtk_application-dark-theme when Notejot.Settings.dark_mode is changed
+                // Notejot.Widgets.Note no longer manages dark theme
+            );
 
             // Main View
             tm = new TaskManager (this);

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -1,0 +1,16 @@
+namespace Notejot {
+    public class Settings : GLib.Settings {
+        public bool dark_mode { get; set; }
+        public string last_view { get; set; }
+        public string font_size { get; set; }
+    
+        public Settings () {
+            Object (
+                schema_id: "io.github.lainsce.Notejot"
+            );
+            bind ("dark-mode", this, "dark-mode", GLib.SettingsBindFlags.DEFAULT);
+            bind ("last-view", this, "last_view", GLib.SettingsBindFlags.DEFAULT);
+            bind ("font-size", this, "font_size", GLib.SettingsBindFlags.DEFAULT);
+        }
+    }
+}

--- a/src/Widgets/Note.vala
+++ b/src/Widgets/Note.vala
@@ -90,10 +90,8 @@ namespace Notejot {
             }
 
             if (Notejot.Application.gsettings.get_boolean("dark-mode")) {
-                Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
                 textfield.get_style_context ().add_class ("notejot-tview-dark-%d".printf(uid));
             } else {
-                Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = false;
                 textfield.get_style_context ().remove_class ("notejot-tview-dark-%d".printf(uid));
             }
 
@@ -103,10 +101,8 @@ namespace Notejot {
                 }
 
                 if (Notejot.Application.gsettings.get_boolean("dark-mode")) {
-                    Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
                     textfield.get_style_context ().add_class ("notejot-tview-dark-%d".printf(uid));
                 } else {
-                    Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = false;
                     textfield.get_style_context ().remove_class ("notejot-tview-dark-%d".printf(uid));
                 }
             });

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -85,7 +85,7 @@ namespace Notejot {
         }
 
         private void set_stylesheet () {
-            if (Notejot.Application.gsettings.get_boolean("dark-mode") == true) {
+            if (Notejot.Application.gsettings.get_boolean("dark-mode")) {
                 this.get_style_context ().add_class ("dark");
                 this.get_style_context ().remove_class ("light");
             } else {


### PR DESCRIPTION
I have fixed #258, Dark theme managing is now handled by the main window and automatically synced with gtk_settings_application_prefer_dark_theme 😄 