### PR TITLE
clear formatting before applying new formatting

### DIFF
--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -130,6 +130,7 @@ namespace Notejot {
             buffer.get_bounds (out start, out end);
 
             string buf = buffer.get_text (start, end, true);
+            buffer.remove_all_tags(start, end);
 
             try {
                 var reg_bold = new Regex("""(?m)(?<bold>\|.*\|)""");

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -133,10 +133,10 @@ namespace Notejot {
             buffer.remove_all_tags(start, end);
 
             try {
-                var reg_bold = new Regex("""(?m)(?<bold>\|.*\|)""");
-                var reg_italic = new Regex("""(?m)(?<italic>\*.*\*)""");
-                var reg_ul = new Regex("""(?m)(?<ul>\_.*\_)""");
-                var reg_s = new Regex("""(?m)(?<strike>\~.*\~)""");
+                var reg_bold = new Regex("""(?s)(?<bold>\|[^|]*\|)""");
+                var reg_italic = new Regex("""(?s)(?<italic>\*[^*]*\*)""");
+                var reg_ul = new Regex("""(?s)(?<ul>\_[^_]*\_)""");
+                var reg_s = new Regex("""(?s)(?<strike>\~[^~]*\~)""");
                 GLib.MatchInfo bmatch;
                 GLib.MatchInfo imatch;
                 GLib.MatchInfo ulmatch;


### PR DESCRIPTION
Fixes #260. 

This clears all tags before reapplying syntax highlighting. Since I barely have any understanding of the application code, this may have unintended side effects, although everything seems to work fine for me.