### PR TITLE
Add translation details to AppStream metadata

### DIFF
--- a/data/io.github.lainsce.Notejot.appdata.xml.in
+++ b/data/io.github.lainsce.Notejot.appdata.xml.in
@@ -52,6 +52,7 @@
         <content_attribute id="money-purchasing">none</content_attribute>
         <content_attribute id="money-gambling">none</content_attribute>
     </content_rating>
+    <translation type="gettext">io.github.lainsce.Notejot</translation>
     <releases>
         <release version="3.1.0" date="2020-08-13">
             <description>


### PR DESCRIPTION
It should show "Localized in your Language" when the translation is available for that language.
I couldn't test this one out, as Builder exports NotejotDevel Flatpak even when I change the profile.

![imagen](https://user-images.githubusercontent.com/42654671/130049528-ce628b6c-3021-4781-8e08-c0bb38962a2e.png)

Source: [https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html](url)