### PR TITLE
formatting improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ sources = files(
    'src/Application.vala',
     'src/MainWindow.vala',
     'src/Settings.vala',
+    'src/Format.vala',
     'src/Services/TaskManager.vala',
     'src/Services/Utils.vala',
     'src/Views/ListView.vala',

--- a/src/Format.vala
+++ b/src/Format.vala
@@ -1,0 +1,44 @@
+namespace Notejot {
+    public enum Format {
+        BOLD,
+        ITALIC,
+        STRIKETHROUGH,
+        UNDERLINE
+    }
+
+    public struct FormatBlock {
+        public int start;
+        public int end;
+        public Format format;
+    }
+
+    public string format_to_string(Format fmt) {
+        switch (fmt) {
+            case Format.BOLD:
+                return "|";
+            case Format.ITALIC:
+                return "*";
+            case Format.STRIKETHROUGH:
+                return "~";
+            case Format.UNDERLINE:
+                return "_";
+            default:
+                assert_not_reached();
+        }
+    }
+
+    public Format string_to_format(string wrap) {
+        switch (wrap) {
+            case "|":
+                return Format.BOLD;
+            case "*":
+                return Format.ITALIC;
+            case "_":
+                return Format.UNDERLINE;
+            case "~":
+                return Format.STRIKETHROUGH;
+            default:
+                assert_not_reached();
+        }
+    }
+}

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -589,11 +589,11 @@ namespace Notejot {
 
             foreach (FormatBlock fmt in textfield.fmt_syntax_blocks()) {
                 // after selection, nothing relevant anymore
-                if (fmt.start > sel_end.get_offset())
+                if (fmt.start > sel_end.get_offset() - 1)
                     break;
 
                 // before selection, not relevant
-                if (fmt.end < sel_start.get_offset())
+                if (fmt.end - 1 < sel_start.get_offset())
                     continue;
 
                 // relative to selected text

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -524,7 +524,7 @@ namespace Notejot {
             builder.erase(real_start, len);
         }
 
-        private void extend_selection_to_format_block() {
+        private void extend_selection_to_format_block(Format? format = null) {
             var textfield = ((Widgets.Note) listview.get_selected_row ()).textfield;
 
             Gtk.TextIter sel_start, sel_end;
@@ -534,6 +534,9 @@ namespace Notejot {
             string wrap;
 
             foreach (FormatBlock fmt in textfield.fmt_syntax_blocks()) {
+                if (format != null && fmt.format != format)
+                    continue;
+
                 // after selection, nothing relevant anymore
                 if (fmt.start > sel_end.get_offset())
                     break;
@@ -550,14 +553,12 @@ namespace Notejot {
                 if (start_rel > 0 && start_rel <= wrap.length) {
                     // selection start does not (entirely) cover the formatters
                     // only touches them -> extend selection
-                    stdout.printf("moving selection start, diff %d\n", sel_start.get_offset() - fmt.start);
                     sel_start.set_offset(fmt.start);
                 }
 
                 if (end_rel > 0 && end_rel <= wrap.length) {
                     // selection end does not (entirely) cover the formatters
                     // only touches them -> extend selection
-                    stdout.printf("moving selection end, diff %d\n", fmt.end - sel_end.get_offset());
                     sel_end.set_offset(fmt.end);
                 }
             }
@@ -666,6 +667,8 @@ namespace Notejot {
         }
 
         public void text_wrap(Gtk.TextView text_view, string wrap, string helptext) {
+            extend_selection_to_format_block(string_to_format(wrap));
+
             var text_buffer = text_view.get_buffer();
             string text;
             int move_back = 0, text_length = 0;

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -27,6 +27,21 @@ namespace Notejot {
         }
     }
 
+    public Format string_to_format(string wrap) {
+        switch (wrap) {
+            case "|":
+                return Format.BOLD;
+            case "*":
+                return Format.ITALIC;
+            case "_":
+                return Format.UNDERLINE;
+            case "~":
+                return Format.STRIKETHROUGH;
+            default:
+                assert_not_reached();
+        }
+    }
+
     public class Widgets.TextField : Gtk.TextView {
         public MainWindow win;
         public new unowned Gtk.TextBuffer buffer;
@@ -176,21 +191,7 @@ namespace Notejot {
                             measure_text = buf[0:match_end_offset];
                             match_end_offset = measure_text.char_count();
 
-                            Format format = Format.BOLD;
-                            switch (match.fetch_named("wrap")) {
-                                case "|":
-                                    format = Format.BOLD;
-                                    break;
-                                case "*":
-                                    format = Format.ITALIC;
-                                    break;
-                                case "_":
-                                    format = Format.UNDERLINE;
-                                    break;
-                                case "~":
-                                    format = Format.STRIKETHROUGH;
-                                    break;
-                            }
+                            Format format = string_to_format(match.fetch_named("wrap"));
 
                             format_blocks += FormatBlock() {
                                 start = match_start_offset,

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -1,47 +1,4 @@
 namespace Notejot {
-    public enum Format {
-        BOLD,
-        ITALIC,
-        STRIKETHROUGH,
-        UNDERLINE
-    }
-
-    public struct FormatBlock {
-        public int start;
-        public int end;
-        public Format format;
-    }
-
-    public string format_to_string(Format fmt) {
-        switch (fmt) {
-            case Format.BOLD:
-                return "|";
-            case Format.ITALIC:
-                return "*";
-            case Format.STRIKETHROUGH:
-                return "~";
-            case Format.UNDERLINE:
-                return "_";
-            default:
-                assert_not_reached();
-        }
-    }
-
-    public Format string_to_format(string wrap) {
-        switch (wrap) {
-            case "|":
-                return Format.BOLD;
-            case "*":
-                return Format.ITALIC;
-            case "_":
-                return Format.UNDERLINE;
-            case "~":
-                return Format.STRIKETHROUGH;
-            default:
-                assert_not_reached();
-        }
-    }
-
     public class Widgets.TextField : Gtk.TextView {
         public MainWindow win;
         public new unowned Gtk.TextBuffer buffer;

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -130,7 +130,7 @@ namespace Notejot {
             int match_start_offset, match_end_offset;
             buffer.get_bounds (out start, out end);
 
-            string buf = buffer.get_text (start, end, true);
+            string measure_text, buf = buffer.get_text (start, end, true);
             buffer.remove_all_tags(start, end);
 
             try {
@@ -146,6 +146,13 @@ namespace Notejot {
                 if (reg_bold.match (buf, 0, out bmatch)) {
                     do {
                         if (bmatch.fetch_named_pos ("bold", out match_start_offset, out match_end_offset)) {
+                            // measure the offset of the actual unicode glyphs,
+                            // not the byte offset
+                            measure_text = buf[0:match_start_offset];
+                            match_start_offset = measure_text.char_count();
+                            measure_text = buf[0:match_end_offset];
+                            match_end_offset = measure_text.char_count();
+
                             buffer.get_iter_at_offset(out match_start, match_start_offset);
                             buffer.get_iter_at_offset(out match_end, match_end_offset);
                             buffer.remove_all_tags(match_start, match_end);
@@ -157,6 +164,11 @@ namespace Notejot {
                 if (reg_italic.match (buf, 0, out imatch)) {
                     do {
                         if (imatch.fetch_named_pos ("italic", out match_start_offset, out match_end_offset)) {
+                            measure_text = buf[0:match_start_offset];
+                            match_start_offset = measure_text.char_count();
+                            measure_text = buf[0:match_end_offset];
+                            match_end_offset = measure_text.char_count();
+
                             buffer.get_iter_at_offset(out match_start, match_start_offset);
                             buffer.get_iter_at_offset(out match_end, match_end_offset);
                             buffer.remove_all_tags(match_start, match_end);
@@ -168,6 +180,11 @@ namespace Notejot {
                 if (reg_ul.match (buf, 0, out ulmatch)) {
                     do {
                         if (ulmatch.fetch_named_pos ("ul", out match_start_offset, out match_end_offset)) {
+                            measure_text = buf[0:match_start_offset];
+                            match_start_offset = measure_text.char_count();
+                            measure_text = buf[0:match_end_offset];
+                            match_end_offset = measure_text.char_count();
+
                             buffer.get_iter_at_offset(out match_start, match_start_offset);
                             buffer.get_iter_at_offset(out match_end, match_end_offset);
                             buffer.remove_all_tags(match_start, match_end);
@@ -179,6 +196,11 @@ namespace Notejot {
                 if (reg_s.match (buf, 0, out smatch)) {
                     do {
                         if (smatch.fetch_named_pos ("strike", out match_start_offset, out match_end_offset)) {
+                            measure_text = buf[0:match_start_offset];
+                            match_start_offset = measure_text.char_count();
+                            measure_text = buf[0:match_end_offset];
+                            match_end_offset = measure_text.char_count();
+
                             buffer.get_iter_at_offset(out match_start, match_start_offset);
                             buffer.get_iter_at_offset(out match_end, match_end_offset);
                             buffer.remove_all_tags(match_start, match_end);

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -1,8 +1,15 @@
 namespace Notejot {
+    public enum Format {
+        BOLD,
+        ITALIC,
+        STRIKETHROUGH,
+        UNDERLINE
+    }
+
     public struct FormatBlock {
         public int start;
         public int end;
-        public Gtk.TextTag format;
+        public Format format;
     }
 
     public class Widgets.TextField : Gtk.TextView {
@@ -154,26 +161,26 @@ namespace Notejot {
                             measure_text = buf[0:match_end_offset];
                             match_end_offset = measure_text.char_count();
 
-                            Gtk.TextTag tag = bold_font;
+                            Format format = Format.BOLD;
                             switch (match.fetch_named("wrap")) {
                                 case "|":
-                                    tag = bold_font;
+                                    format = Format.BOLD;
                                     break;
                                 case "*":
-                                    tag = italic_font;
+                                    format = Format.ITALIC;
                                     break;
                                 case "_":
-                                    tag = ul_font;
+                                    format = Format.UNDERLINE;
                                     break;
                                 case "~":
-                                    tag = s_font;
+                                    format = Format.STRIKETHROUGH;
                                     break;
                             }
 
                             format_blocks += FormatBlock() {
                                 start = match_start_offset,
                                 end = match_end_offset,
-                                format = tag
+                                format = format
                             };
                         }
                     } while (match.next());
@@ -195,7 +202,23 @@ namespace Notejot {
                 buffer.get_iter_at_offset (out fmt_start, fmt.start);
                 buffer.get_iter_at_offset (out fmt_end, fmt.end);
 
-                buffer.apply_tag (fmt.format, fmt_start, fmt_end);
+                Gtk.TextTag tag = bold_font;
+                switch (fmt.format) {
+                    case Format.BOLD:
+                        tag = bold_font;
+                        break;
+                    case Format.ITALIC:
+                        tag = italic_font;
+                        break;
+                    case Format.STRIKETHROUGH:
+                        tag = s_font;
+                        break;
+                    case Format.UNDERLINE:
+                        tag = ul_font;
+                        break;
+                }
+
+                buffer.apply_tag (tag, fmt_start, fmt_end);
             }
 
             update_idle_source = 0;

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -12,6 +12,21 @@ namespace Notejot {
         public Format format;
     }
 
+    public string format_to_string(Format fmt) {
+        switch (fmt) {
+            case Format.BOLD:
+                return "|";
+            case Format.ITALIC:
+                return "*";
+            case Format.STRIKETHROUGH:
+                return "~";
+            case Format.UNDERLINE:
+                return "_";
+            default:
+                assert_not_reached();
+        }
+    }
+
     public class Widgets.TextField : Gtk.TextView {
         public MainWindow win;
         public new unowned Gtk.TextBuffer buffer;

--- a/src/Widgets/TextField.vala
+++ b/src/Widgets/TextField.vala
@@ -1,4 +1,10 @@
 namespace Notejot {
+    public struct FormatBlock {
+        public int start;
+        public int end;
+        public Gtk.TextTag format;
+    }
+
     public class Widgets.TextField : Gtk.TextView {
         public MainWindow win;
         public new unowned Gtk.TextBuffer buffer;
@@ -125,27 +131,22 @@ namespace Notejot {
             });
         }
 
-        private bool fmt_syntax () {
-            Gtk.TextIter start, end, match_start, match_end;
+        public FormatBlock[] fmt_syntax_blocks() {
+            Gtk.TextIter start, end;
             int match_start_offset, match_end_offset;
-            buffer.get_bounds (out start, out end);
+            FormatBlock[] format_blocks = {};
 
+            GLib.MatchInfo match;
+
+            buffer.get_bounds(out start, out end);
             string measure_text, buf = buffer.get_text (start, end, true);
-            buffer.remove_all_tags(start, end);
 
             try {
-                var reg_bold = new Regex("""(?s)(?<bold>\|[^|]*\|)""");
-                var reg_italic = new Regex("""(?s)(?<italic>\*[^*]*\*)""");
-                var reg_ul = new Regex("""(?s)(?<ul>\_[^_]*\_)""");
-                var reg_s = new Regex("""(?s)(?<strike>\~[^~]*\~)""");
-                GLib.MatchInfo bmatch;
-                GLib.MatchInfo imatch;
-                GLib.MatchInfo ulmatch;
-                GLib.MatchInfo smatch;
+                var regex = new Regex("""(?s)(?<wrap>[*_|~]).*?\g{wrap}""");
 
-                if (reg_bold.match (buf, 0, out bmatch)) {
+                if (regex.match (buf, 0, out match)) {
                     do {
-                        if (bmatch.fetch_named_pos ("bold", out match_start_offset, out match_end_offset)) {
+                        if (match.fetch_pos (0, out match_start_offset, out match_end_offset)) {
                             // measure the offset of the actual unicode glyphs,
                             // not the byte offset
                             measure_text = buf[0:match_start_offset];
@@ -153,63 +154,48 @@ namespace Notejot {
                             measure_text = buf[0:match_end_offset];
                             match_end_offset = measure_text.char_count();
 
-                            buffer.get_iter_at_offset(out match_start, match_start_offset);
-                            buffer.get_iter_at_offset(out match_end, match_end_offset);
-                            buffer.remove_all_tags(match_start, match_end);
-                            buffer.apply_tag(bold_font, match_start, match_end);
+                            Gtk.TextTag tag = bold_font;
+                            switch (match.fetch_named("wrap")) {
+                                case "|":
+                                    tag = bold_font;
+                                    break;
+                                case "*":
+                                    tag = italic_font;
+                                    break;
+                                case "_":
+                                    tag = ul_font;
+                                    break;
+                                case "~":
+                                    tag = s_font;
+                                    break;
+                            }
+
+                            format_blocks += FormatBlock() {
+                                start = match_start_offset,
+                                end = match_end_offset,
+                                format = tag
+                            };
                         }
-                    } while (bmatch.next ());
-                }
-
-                if (reg_italic.match (buf, 0, out imatch)) {
-                    do {
-                        if (imatch.fetch_named_pos ("italic", out match_start_offset, out match_end_offset)) {
-                            measure_text = buf[0:match_start_offset];
-                            match_start_offset = measure_text.char_count();
-                            measure_text = buf[0:match_end_offset];
-                            match_end_offset = measure_text.char_count();
-
-                            buffer.get_iter_at_offset(out match_start, match_start_offset);
-                            buffer.get_iter_at_offset(out match_end, match_end_offset);
-                            buffer.remove_all_tags(match_start, match_end);
-                            buffer.apply_tag(italic_font, match_start, match_end);
-                        }
-                    } while (imatch.next ());
-                }
-
-                if (reg_ul.match (buf, 0, out ulmatch)) {
-                    do {
-                        if (ulmatch.fetch_named_pos ("ul", out match_start_offset, out match_end_offset)) {
-                            measure_text = buf[0:match_start_offset];
-                            match_start_offset = measure_text.char_count();
-                            measure_text = buf[0:match_end_offset];
-                            match_end_offset = measure_text.char_count();
-
-                            buffer.get_iter_at_offset(out match_start, match_start_offset);
-                            buffer.get_iter_at_offset(out match_end, match_end_offset);
-                            buffer.remove_all_tags(match_start, match_end);
-                            buffer.apply_tag(ul_font, match_start, match_end);
-                        }
-                    } while (ulmatch.next ());
-                }
-
-                if (reg_s.match (buf, 0, out smatch)) {
-                    do {
-                        if (smatch.fetch_named_pos ("strike", out match_start_offset, out match_end_offset)) {
-                            measure_text = buf[0:match_start_offset];
-                            match_start_offset = measure_text.char_count();
-                            measure_text = buf[0:match_end_offset];
-                            match_end_offset = measure_text.char_count();
-
-                            buffer.get_iter_at_offset(out match_start, match_start_offset);
-                            buffer.get_iter_at_offset(out match_end, match_end_offset);
-                            buffer.remove_all_tags(match_start, match_end);
-                            buffer.apply_tag(s_font, match_start, match_end);
-                        }
-                    } while (smatch.next ());
+                    } while (match.next());
                 }
             } catch (GLib.RegexError re) {
                 warning ("%s".printf(re.message));
+            }
+
+            return format_blocks;
+        }
+
+        private bool fmt_syntax () {
+            Gtk.TextIter start, end, fmt_start, fmt_end;
+
+            buffer.get_bounds (out start, out end);
+            buffer.remove_all_tags (start, end);
+
+            foreach (FormatBlock fmt in fmt_syntax_blocks ()) {
+                buffer.get_iter_at_offset (out fmt_start, fmt.start);
+                buffer.get_iter_at_offset (out fmt_end, fmt.end);
+
+                buffer.apply_tag (fmt.format, fmt_start, fmt_end);
             }
 
             update_idle_source = 0;


### PR DESCRIPTION
First of all: This is a quite big pull request. I tried to add explanatory comments where helpful and I will also try sum up the changes I made to the overall codebase below. If you have any questions or want things to be done differently, I'll try to do my best 😊.

What I tried to achieve in this PR is, to implement something similar to what I proposed in https://github.com/lainsce/notejot/pull/261#issuecomment-902328366.

In the process of implementing, I also touched some of the other related parts.

# syntax format calculation

The text is now searched with one single big regex in `fmt_syntax_blocks()`, which returns a list of `FormatBlock`s. They describe ranges in the text, where a single format applies. The result of this can be seen below:

![syntax_blocks_calculation](https://user-images.githubusercontent.com/59307989/130364212-97c80710-b474-4cbf-a8f2-4f37d153312e.png)

As you can see from the "chaos" on the left, this does remove some confusion, where overlapping formats would intersect. Additionally, no formats are prioritized over others, but rather the first one that occurs is applied.

# action_normal behaviour

As described above, I completely changed (and complicated :grinning:) the way, the `ab`- or "normal"-button works. I implemented the two proposals I had in [the issue comment](https://github.com/lainsce/notejot/pull/261#issuecomment-902328366). The first point (also remove formatting if only the formatted text is selected), is mainly implemented in `extend_selection_to_format_block()`. The second point is contained in the complete rewrite of the `action_normal` function.

https://user-images.githubusercontent.com/59307989/130365113-31ff6078-4d8a-47c7-b2f1-2dd239433096.mp4

As you can see, the algorithm tries to to *only* clean up the selected range and does preserve potential formatting around. This may even split up a format block (`|complex|` -> `|co|mpl|ex|`). The implementation does use `fmt_syntax_blocks()` to be as "intelligent" as possible. If you have any wishes, how the `ab` button should behave differently, let me know. The current implementation does correspond to what I would expect it to do.

# user actions

`Gtk.TextBuffer` offers the possibility to mark certain groups of actions as one single action ([valadoc](https://valadoc.org/gtk4/Gtk.TextBuffer.begin_user_action.html) and [GTK docs](https://docs.gtk.org/gtk4/vfunc.TextBuffer.begin_user_action.html)).

This should, in theory, allow to do a single `Ctrl+Z` to undo the button action and not two. This currently does not work for me, probably because of [this GTK bug](https://gitlab.gnome.org/GNOME/gtk/-/issues/3977), for which the fix is not yet in my GTK4 version.

# conclusion

As you can see, this PR contains various different changes that partially depend on each other. If you prefer it, I can try to split this whole thing up into several small PRs that I would then file one after the other.

Thanks for this application and your time!