### PR TITLE
Fix permanent window maximization at startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -282,10 +282,10 @@ namespace Notejot {
 
         protected override bool close_request () {
             debug ("Exiting window... Disposing of stuff...");
-            
-            if (is_maximized())
-                Application.gsettings.set_boolean("is-maximized", is_maximized ());
-            else {
+
+            Application.gsettings.set_boolean("is-maximized", is_maximized ());
+
+            if (!is_maximized()) {
                 Application.gsettings.set_int("window-w", get_width ());
                 Application.gsettings.set_int("window-h", get_height ());
             }


### PR DESCRIPTION
Keeps the window maximized at startup only when it is closed in that state (same behavior as GNOME system apps).

In the latest version, once it closes maximized, it opens in that state the rest of the times.