### PR TITLE
Fix display_length requirement in appdata

### DIFF
--- a/data/io.github.lainsce.Notejot.appdata.xml.in
+++ b/data/io.github.lainsce.Notejot.appdata.xml.in
@@ -24,14 +24,14 @@
             <image>https://raw.githubusercontent.com/lainsce/notejot/master/data/shot.png</image>
         </screenshot>
     </screenshots>
-    <content_rating type="oars-1.1" />
+    <content_rating type="oars-1.1"/>
     <recommends>
       <control>keyboard</control>
       <control>pointing</control>
       <control>touch</control>
     </recommends>
     <requires>
-      <display_length compare="ge">medium</display_length>
+      <display_length compare="ge">768</display_length>
     </requires>
     <translation type="gettext">io.github.lainsce.Notejot</translation>
     <releases>


### PR DESCRIPTION
I've just read [this post](https://blogs.gnome.org/tbernard/2021/09/07/ready-for-software-41/) and as it points out, display_length size constants are broken, so it's now changed to its numerical equivalent.