### PR TITLE
Fix crash caused by two objects having the same ID

### DIFF
--- a/data/ui/main_window.ui
+++ b/data/ui/main_window.ui
@@ -106,7 +106,7 @@
                                   <class name="notejot-view"/>
                                 </style>
                                 <child type="placeholder">
-                                  <object class="AdwStatusPage" id="placeholder">
+                                  <object class="AdwStatusPage">
                                     <property name="valign">center</property>
                                     <property name="hexpand">0</property>
                                     <property name="vexpand">1</property>
@@ -136,7 +136,7 @@
                                   <class name="notejot-view"/>
                                 </style>
                                 <child type="placeholder">
-                                  <object class="AdwStatusPage" id="placeholder">
+                                  <object class="AdwStatusPage">
                                     <property name="valign">center</property>
                                     <property name="vexpand">1</property>
                                     <property name="icon-name">user-trash-symbolic</property>


### PR DESCRIPTION
The main_window.ui file lists two objects with the same ID, preventing
the app from starting with:

(io.github.lainsce.Notejot:644523): Gtk-CRITICAL **: 15:15:03.493: Error building template class 'NotejotMainWindow' for an instance of type 'NotejotMainWindow': .:0:0 Duplicate object ID 'placeholder' (previously on line 0)

None of these objects is referenced in the MainWindow.vala file,
therefore dropping the IDs entirely fixes the issue.

This was initially reported at https://bugzilla.redhat.com/2002210