### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
-# ![icon](data/icon.png) Notejot
+<img align="left" style="vertical-align: middle" width="120" height="120" src="data/icon.png">
 
-## Stupidly simple notes app
+# Notejot
 
-<a href='https://flathub.org/apps/details/io.github.lainsce.Notejot'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
+Stupidly simple notes app
+
+###
 
 [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 
 ![Screenshot](data/shot.png)
 
-## Donations 
+<p align="center"><a href='https://flathub.org/apps/details/io.github.lainsce.Notejot'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a></p>
+
+## 💝 Donations 
 
 Would you like to support the development of this app to new heights? Then:
 
 [Be my backer on Patreon](https://www.patreon.com/lainsce)
 
-## Dependencies
+## 🛠️ Dependencies
 
 Please make sure you have these dependencies first before building.
 
@@ -28,14 +32,14 @@ meson
 vala
 ```
 
-## Building
+## 🏗️ Building
 
 Simply clone this repo, then:
 
 ```bash
-meson build --prefix=/usr && cd build
+meson _build --prefix=/usr && cd _build
 sudo ninja install
 ```
 
-## Notes Storage
+## 🗂️ Notes Storage
 Notes are stored in `~/.var/app/io.github.lainsce.Notejot/`

--- a/po/README.md
+++ b/po/README.md
@@ -1,19 +1,19 @@
-# How to Translate Notejot
+# 🌐 How to Translate Notejot
 
-## First Things First
+## ✏️ First Things First
 
 * Fork the repository here on github with the Fork button at the top-right
 * Clone this repository by opening the terminal in a folder of your choice and typing `git clone https://github.com/<you_username>/notejot`
 * (Optional) Check [Regenerate translations files](https://github.com/lainsce/notejot/tree/master/po#regenerate-translations-files) section if files haven't been recently updated.
 
-## Basics
+## 📃 Basics
 
 * You'll need to know your language's code (ex. en = English).
 * Add that code to the LINGUAS file, in a new line, after the last line.
 * Translate the .pot file using the PO editor of your choice (I recommend POEdit).
 * Save it as <language_code>.po in this folder.
 
-## Not so Basics
+## 📝 Not so Basics
 
 * Next, in the folder you've cloned this repo in, open a terminal and type: ```git checkout -b "Translation <language code>```
 * Then, type ```git add *```
@@ -21,9 +21,9 @@
 
 And that's it! You've successfully translated Notejot for your language!
 
-## Regenerate translations files
+## 🔁 Regenerate translations files
 * Initialize the project build by typing `meson _build` (make sure you have [dependencies](https://github.com/lainsce/notejot#dependencies) installed!).
 * Compile .pot files, type `meson compile -C _build io.github.lainsce.Notejot-pot` and `meson compile -C _build extra-pot`
 * (Optional) Compile .po files instead replacing `-pot` with `-update-po` in the previous commands.
 
-Note: install `apppstream` package in order to generate release strings in `extra.pot`
+Note: install `appstream` package in order to generate release strings in `extra.pot`


### PR DESCRIPTION
Well, this started as a fix  for a few lines but it ended up like [this](https://github.com/oscfdezdz/notejot/blob/readme/README.md) and translations' one like [this](https://github.com/oscfdezdz/notejot/blob/readme/po/README.md). I'm not sure of the positions of the badges and download, feel free to change anything 😄

I'll revert the changes if you don't want/like them and leave only the ones in Building section,  `_build` directory instead of `build` to match translations' README (it could be the other way around) and remove an extra `p` in the `appstream` word.