### PR TITLE
Bump flatpak job version

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -4,15 +4,15 @@ on:
   pull_request:
 name: CI
 jobs:
-  flatpak-builder:
-    name: "Flatpak Builder"
+  flatpak:
+    name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-3.38
+      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-      - uses: actions/checkout@v2
-      - uses: bilelmoussaoui/flatpak-github-actions@v2
+      - uses: actions/checkout@v2.3.5
+      - uses: bilelmoussaoui/flatpak-github-actions@v4
         with:
           bundle: "notejot-nightly.flatpak"
           manifest-path: "build-aux/flatpak/io.github.lainsce.Notejot.json"


### PR DESCRIPTION
Maybe it would be a better idea to point the version of the image to stable 41 and not to nightly 🤔 