### PR TITLE
Initialize translations properly

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,6 +26,9 @@ public class Notejot.Application : Adw.Application {
         Object (application_id: Config.APP_ID);
     }
     public static int main (string[] args) {
+        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.GNOMELOCALEDIR);
+        Intl.textdomain (Config.GETTEXT_PACKAGE);
+
         var app = new Notejot.Application ();
         return app.run (args);
     }


### PR DESCRIPTION
Solves regression introduced in 6f53d71ffa5d2fcc5a0c7c782954bca79da638a7 and improves faeaff5d9a113d022f6405eb1a217770e2395d5c implementation, following GNOME core apps example such as [Clocks](https://gitlab.gnome.org/GNOME/gnome-clocks/-/blob/master/src/main.vala#L21).

Part of https://github.com/lainsce/notejot/issues/313