### PR TITLE
git: rename default branch to main

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 name: CI
 jobs:

--- a/data/io.github.lainsce.Notejot.appdata.xml.in
+++ b/data/io.github.lainsce.Notejot.appdata.xml.in
@@ -22,10 +22,10 @@
     <url type="homepage">https://github.com/lainsce/notejot/</url>
     <url type="bugtracker">https://github.com/lainsce/notejot/issues</url>
     <url type="donation">https://www.ko-fi.com/lainsce/</url>
-    <url type="translate">https://github.com/lainsce/notejot/blob/master/po/README.md</url>
+    <url type="translate">https://github.com/lainsce/notejot/blob/main/po/README.md</url>
     <screenshots>
         <screenshot type="default">
-            <image>https://raw.githubusercontent.com/lainsce/notejot/master/data/shot.png</image>
+            <image>https://raw.githubusercontent.com/lainsce/notejot/main/data/shot.png</image>
         </screenshot>
     </screenshots>
     <content_rating type="oars-1.1" />

--- a/po/README.md
+++ b/po/README.md
@@ -4,7 +4,7 @@
 
 * Fork the repository here on github with the Fork button at the top-right
 * Clone this repository by opening the terminal in a folder of your choice and typing `git clone https://github.com/<you_username>/notejot`
-* (Optional) Check [Regenerate translations files](https://github.com/lainsce/notejot/tree/master/po#-regenerate-translations-files) section if files haven't been recently updated.
+* (Optional) Check [Regenerate translations files](https://github.com/lainsce/notejot/tree/main/po#-regenerate-translations-files) section if files haven't been recently updated.
 
 ## 📃 Basics
 


### PR DESCRIPTION
Since it's becoming the default option, I thought it would be a good idea to make the change :)

It needs to be changed on [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) and locally it would require:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```