### PR TITLE
build: cleanup and reorganization

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -11,7 +11,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
       - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
         with:
           bundle: io.github.lainsce.Notejot.Devel.flatpak

--- a/data/io.github.lainsce.Notejot.desktop.in
+++ b/data/io.github.lainsce.Notejot.desktop.in
@@ -2,7 +2,7 @@
 Name=Notejot
 Comment=Jot your ideas
 Exec=io.github.lainsce.Notejot
-Icon=@icon@
+Icon=@app_id@
 Keywords=text;plain;plaintext;notepad;notes;sticky;post-it;
 Terminal=false
 Type=Application

--- a/data/io.github.lainsce.Notejot.metainfo.xml.in
+++ b/data/io.github.lainsce.Notejot.metainfo.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-    <id>io.github.lainsce.Notejot</id>
+    <id>@app_id@</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0+</project_license>
     <name translatable="no">Notejot</name>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,45 +1,54 @@
-install_data(
-  meson.project_name() + '.gschema.xml',
-  install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
+conf = configuration_data()
+conf.set('app_id', app_id)
+
+desktop_conf = configure_file(
+  input: meson.project_name() + '.desktop.in',
+  output: '@0@.desktop.in'.format(app_id),
+  configuration: conf
 )
 
-msgfmt = find_program('msgfmt')
-podir = join_paths(meson.source_root(), 'po')
-desktop_conf = configuration_data()
-desktop_conf.set('icon', app_id)
-desktop_file = custom_target('desktop-file',
-  input: configure_file(
-    input: meson.project_name() + '.desktop.in',
-    output: '@BASENAME@' + '.in',
-    configuration: desktop_conf
-  ),
+desktop_file = i18n.merge_file(
+  input: desktop_conf,
   output: '@0@.desktop'.format(app_id),
+  type: 'desktop',
+  po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'applications'),
-  command: [msgfmt, '--desktop',
-    '--template', '@INPUT@', '-d', podir, '-o', '@OUTPUT@',
-    '--keyword=X-GNOME-FullName', '--keyword=X-Geoclue-Reason',
-    '--keyword=Name', '--keyword=GenericName', '--keyword=Comment', '--keyword=Keywords'
-  ]
+  install_dir: join_paths(get_option('datadir'), 'applications')
 )
+
 # Validate Desktop file
 desktop_file_validate = find_program('desktop-file-validate', required: false)
 if desktop_file_validate.found()
-  test(
-    'validate-desktop',
-    desktop_file_validate,
-    args: [
-      desktop_file.full_path()
-    ]
+  test('validate-desktop', desktop_file_validate,
+    args: [desktop_file]
   )
 endif
 
-i18n.merge_file(
+appstream_conf = configure_file(
   input: meson.project_name() + '.metainfo.xml.in',
-  output: meson.project_name() + '.metainfo.xml',
-  po_dir: podir,
+  output: '@0@.metainfo.xml.in'.format(app_id),
+  configuration: conf
+)
+
+appstream_file = i18n.merge_file(
+  input: appstream_conf,
+  output: '@0@.metainfo.xml'.format(app_id),
+  po_dir: '../po',
   install: true,
   install_dir: join_paths(get_option('datadir'), 'metainfo')
+)
+
+#Validate Appstream file
+appstream_file_validate = find_program('appstream-util', required: false)
+if appstream_file_validate.found()
+  test('validate-appstream', appstream_file_validate,
+    args: ['validate', '--nonet', appstream_file]
+  )
+endif
+
+install_data(
+  meson.project_name() + '.gschema.xml',
+  install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
 )
 
 subdir('icons')

--- a/io.github.lainsce.Notejot.Devel.json
+++ b/io.github.lainsce.Notejot.Devel.json
@@ -11,7 +11,7 @@
         "--share=ipc",
         "--device=dri"
     ],
-    "desktop-file-name-suffix" : " (Devel)",
+    "desktop-file-name-suffix" : " (Development)",
     "cleanup" : [
         "/cache",
         "/man",
@@ -84,20 +84,17 @@
         },
         {
             "name" : "notejot",
+            "builddir" : true,
             "buildsystem" : "meson",
             "config-opts" : [
-                "-Dprofile=development"
+                "-Ddevelopment=true"
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/lainsce/notejot.git",
-                    "branch" : "main"
+                    "type" : "dir",
+                    "path" : "."
                 }
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {        }
-    }
+    ]
 }

--- a/meson.build
+++ b/meson.build
@@ -8,44 +8,37 @@ add_project_arguments([
 	language: 'vala',
 )
 
-if get_option('profile') == 'development'
-  name_prefix = '(Development) '
-  profile = '.Devel'
+if get_option('development')
+  app_id = 'io.github.lainsce.Notejot.Devel'
+  name_suffix = ' (Development)'
 else
-  name_prefix = ''
-  profile = ''
+  app_id = 'io.github.lainsce.Notejot'
+  name_suffix = ''
 endif
-
-app_id = '@0@@1@'.format(meson.project_name(), profile)
 
 conf = configuration_data()
 conf.set_quoted('APP_ID', app_id)
-conf.set_quoted('G_LOG_DOMAIN', '@0@@1@'.format(meson.project_name(), profile))
-conf.set_quoted('NAME_PREFIX', name_prefix)
-conf.set_quoted('PACKAGE_NAME', meson.project_name())
-conf.set_quoted('PACKAGE_VERSION', meson.project_version())
-conf.set_quoted('PROFILE', profile)
+conf.set_quoted('NAME_SUFFIX', name_suffix)
 conf.set_quoted('VERSION', meson.project_version())
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
-conf.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
-conf.set_quoted('GNOMELOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set10('DEVELOPMENT', get_option('development'))
 configure_file(output: 'config.h', configuration: conf)
 config_h_dir = include_directories('.')
 
-
 add_project_arguments(
-    '-include', 'config.h',
-    '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
-    language: 'c'
+  '-include', 'config.h',
+  '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+  language: 'c'
 )
 
 asresources = gnome.compile_resources(
-    'as-resources', 'data/io.github.lainsce.Notejot.gresource.xml',
-    source_dir: 'data',
-    c_name: 'as'
+  'as-resources', 'data/io.github.lainsce.Notejot.gresource.xml',
+  source_dir: 'data',
+  c_name: 'as'
 )
 
-sources = files(
+sources = [
   'src/Application.vala',
   'src/MainWindow.vala',
   'src/Models/Note.vala',
@@ -83,27 +76,27 @@ sources = files(
   'src/Widgets/NoteTheme.vala',
   'src/Widgets/TrashRowBadge.vala',
   'src/Widgets/TrashRowContent.vala',
-)
+]
 
 dependencies = [
-    dependency('gio-2.0'),
-    dependency('gtk4'),
-    dependency('glib-2.0'),
-    dependency('gobject-2.0'),
-    dependency('gee-0.8'),
-    dependency('libadwaita-1'),
-    dependency('gmodule-2.0'),
-    dependency('json-glib-1.0'),
-    meson.get_compiler('c').find_library('m', required: true)
+  dependency('gio-2.0'),
+  dependency('gtk4'),
+  dependency('glib-2.0'),
+  dependency('gobject-2.0'),
+  dependency('gee-0.8'),
+  dependency('libadwaita-1'),
+  dependency('gmodule-2.0'),
+  dependency('json-glib-1.0'),
+  meson.get_compiler('c').find_library('m', required: true)
 ]
 
 executable(
-    meson.project_name(),
-    sources,
-    asresources,
-    dependencies: dependencies,
-    vala_args: [meson.source_root() + '/src/Config.vapi'],
-    install : true
+  meson.project_name(),
+  sources,
+  asresources,
+  dependencies: dependencies,
+  vala_args: [meson.source_root() + '/src/Config.vapi'],
+  install : true
 )
 
 subdir('data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,1 @@
-option(
-  'profile',
-  type: 'combo',
-  choices: [
-    'default',
-    'development',
-  ],
-  value: 'default',
-  description: 'The build profile for Notejot. One of "default" or "development".'
-)
+option('development', type: 'boolean', value: false, description: 'If this is a development build')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,7 +26,7 @@ public class Notejot.Application : Adw.Application {
         Object (application_id: Config.APP_ID);
     }
     public static int main (string[] args) {
-        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.GNOMELOCALEDIR);
+        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
         Intl.textdomain (Config.GETTEXT_PACKAGE);
 
         var app = new Notejot.Application ();

--- a/src/Config.vapi
+++ b/src/Config.vapi
@@ -18,11 +18,10 @@
 */
 [CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
 namespace Config {
-    public const string VERSION;
-    public const string PROFILE;
-    public const string NAME_SUFFIX;
-    public const string GETTEXT_PACKAGE;
-    public const string GNOMELOCALEDIR;
-    public const string DATADIR;
     public const string APP_ID;
+    public const string NAME_SUFFIX;
+    public const string VERSION;
+    public const string GETTEXT_PACKAGE;
+    public const string LOCALEDIR;
+    public const bool DEVELOPMENT;
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -109,8 +109,9 @@ namespace Notejot {
             var action_fontsize = settings.create_action ("font-size");
             app.add_action(action_fontsize);
 
-            if (Config.PROFILE == ".Devel")
+            if (Config.DEVELOPMENT) {
                 add_css_class ("devel");
+            }
 
             // Migrate things from old version
             if (settings.schema_version == 0) {
@@ -254,9 +255,8 @@ namespace Notejot {
                 null
             };
 
-            var program_name = "Notejot";
             Gtk.show_about_dialog (this,
-                                   "program-name", program_name,
+                                   "program-name", "Notejot" + Config.NAME_SUFFIX,
                                    "logo-icon-name", Config.APP_ID,
                                    "version", Config.VERSION,
                                    "comments", _("Jot your ideas."),

--- a/src/Widgets/EditNotebookDialog.vala
+++ b/src/Widgets/EditNotebookDialog.vala
@@ -44,6 +44,10 @@ namespace Notejot {
                     notebook_add_button.sensitive = false;
                 }
             });
+
+            if (Config.DEVELOPMENT) {
+                add_css_class ("devel");
+            }
         }
 
         [GtkCallback]

--- a/src/Widgets/MoveToDialog.vala
+++ b/src/Widgets/MoveToDialog.vala
@@ -62,6 +62,10 @@ namespace Notejot {
             } else {
                 remove_notebook_button.sensitive = true;
             }
+
+            if (Config.DEVELOPMENT) {
+                add_css_class ("devel");
+            }
         }
 
         [GtkCallback]


### PR DESCRIPTION
These changes have been tested with both manifests, stable and devel, as well as manually builded without regressions/warnings whatsoever.

- Bump checkout action to v2.4.0.
- Reorganized `data/meson.build` and added metainfo file validation.
- Name prefix is now a suffix.
- Reverted manifest's source type to 'dir' as it breaks CI in forks.
- Meson build option is now a bool to avoid writing '.Devel' to files where necessary.
- Removed `G_LOG_DOMAIN`, `PACKAGE_NAME`, `PACKAGE_VERSION` and `DATADIR` as they are unused.
- Added devel style to 'Move To' and 'Edit Notebook' dialogs when needed.

Hopefully I can get all changes I did in future PRs without breaking it 😄 