### PR TITLE
Add <launchable/> tag to AppStream metadata

### DIFF
--- a/data/io.github.lainsce.Notejot.metainfo.xml.in
+++ b/data/io.github.lainsce.Notejot.metainfo.xml.in
@@ -26,6 +26,7 @@
     <url type="bugtracker">https://github.com/lainsce/notejot/issues</url>
     <url type="donation">https://www.ko-fi.com/lainsce/</url>
     <url type="translate">https://github.com/lainsce/notejot/blob/main/po/README.md</url>
+    <launchable type="desktop-id">io.github.lainsce.Notejot.desktop</launchable>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/lainsce/notejot/main/data/shot.png</image>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-launchable-info

Omitting this tag now now triggers a hard validation error in `appstreamcli validate`:

https://github.com/ximion/appstream/commit/ad98bfd8db789c80507e82278d6d766acba4937c