### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/io.github.lainsce.Notejot.metainfo.xml.in
+++ b/data/io.github.lainsce.Notejot.metainfo.xml.in
@@ -21,7 +21,9 @@
       <kudo>ModernToolkit</kudo>
       <kudo>HiDpiIcon</kudo>
     </kudos>
-    <developer_name translatable="no">Lains</developer_name>
+    <developer>
+        <name translatable="no">Lains</name>
+    </developer>
     <url type="homepage">https://github.com/lainsce/notejot/</url>
     <url type="bugtracker">https://github.com/lainsce/notejot/issues</url>
     <url type="donation">https://www.ko-fi.com/lainsce/</url>

--- a/data/io.github.lainsce.Notejot.metainfo.xml.in
+++ b/data/io.github.lainsce.Notejot.metainfo.xml.in
@@ -21,7 +21,7 @@
       <kudo>ModernToolkit</kudo>
       <kudo>HiDpiIcon</kudo>
     </kudos>
-    <developer>
+    <developer id="us.lainsce">
         <name translatable="no">Lains</name>
     </developer>
     <url type="homepage">https://github.com/lainsce/notejot/</url>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: io.github.lainsce.Notejot:37: description-first-para-too-short
     A stupidly-simple notes application for any type of short term notes or ideas.
   The first `description/p` paragraph of this component might be too short (< 80 characters).
   Please consider starting with a longer paragraph to improve how the description looks like in
   software centers and to provide more detailed information on this component immediately in the
   first paragraph.

I: io.github.lainsce.Notejot:91: nonstandard-gnome-extension kudos
   This tag is a GNOME-specific extension to AppStream and not part of the official specification.
   Do not expect it to work in all implementations and in all software centers.

I: io.github.lainsce.Notejot:95: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

✔ Validation was successful: infos: 3, pedantic: 2
```